### PR TITLE
Make CreateKey faster

### DIFF
--- a/Maploader/World/World.cs
+++ b/Maploader/World/World.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -460,16 +461,10 @@ namespace Maploader.World
 
         private static byte[] CreateKey(int x, int z)
         {
-            // Todo: make it faster
             var key = new byte[10];
-            using (var ms = new MemoryStream(key))
-            using (var bs = new BinaryWriter(ms))
-            {
-                bs.Write(x);
-                bs.Write(z);
-                bs.Write((byte) 47);
-            }
-
+            BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(), x);
+            BinaryPrimitives.WriteInt32LittleEndian(key.AsSpan(4), z);
+            key[8] = 47;
             return key;
         }
 
@@ -574,10 +569,9 @@ namespace Maploader.World
                 Z = z,
             };
 
-
+            var key = CreateKey(x, z);
             foreach (var kvp in Enumerable.Range(0,15))
             {
-                var key = CreateKey(x, z);
                 key[9] = (byte)kvp;
 
                 UIntPtr length;

--- a/PapyrusCs/PapyrusCs.csproj
+++ b/PapyrusCs/PapyrusCs.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This addresses a "TODO" in the code:

* Use `BinaryPrimitives` instead of `BinaryWriter` to write directly to the array instead of via a `MemoryStream`.
* Move allocation of the key outside the loop to avoid creating unnecessary temporary objects.

For a local Minecraft map, this change reduced the first phase from 3:33.6 to 3:21.7.