### PR TITLE
Fix furnace, lit furnace to use top texture

### DIFF
--- a/Maploader/Renderer/Texture/TextureFinder.cs
+++ b/Maploader/Renderer/Texture/TextureFinder.cs
@@ -807,8 +807,9 @@ namespace Maploader.Renderer.Texture
                         new Rect(0, 0, 4, 16)
                     ));
 
+                case "furnace":
                 case "lit_furnace":
-                    return GetTexture("redstone_torch_off", data);
+                    return GetTexture("furnace_top", data);
 
                 case "concrete":
                     return GetTexture("concrete", data);


### PR DESCRIPTION
Fixes the furnace texture (which was the front) and the lit furnace texture (which was `redstone_torch_off`)